### PR TITLE
Disable require-await rule

### DIFF
--- a/lib/typescript.js
+++ b/lib/typescript.js
@@ -60,6 +60,8 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-unsafe-return': 'off',
         '@typescript-eslint/no-empty-function': 'off',
+        // Returning a promise without using "await" is valid
+        '@typescript-eslint/require-await': 'off',
       },
     },
     {


### PR DESCRIPTION
When upgrading linting in social-circle-service project to use these configs, I saw lots of errors saying "await is required in an async function". I fixed them all by removing `async` from function declaration, and, in 95% of the cases it was the right thing to do, but in other 5% it wasn't the right thing to do:

```
async function someFunction() {
  return Promise.resolve(5)
}

// require-await will complain here about missing await even though not having await here is completely valid.
// When fixing such issues in bulk, the intuitive thing to do is to remove the `async` modifier here which isn't the right thing to do obviously
async function theFunction() {
  return someFunction();
}
```