### PR TITLE
[BREAKING] fix: allow ESLint v8 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "semantic-release": "^17.4.7"
   },
   "peerDependencies": {
-    "eslint": ">=7"
+    "eslint": "7.x || 8.x"
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^4.29.3",


### PR DESCRIPTION
## Motivation
ESLint v8 was recently released. The only breaking rule changes were new additions. I made this a breaking change for that reason.

Breaking changes in v8: https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#eslintrecommended-has-been-updated