### PR TITLE
chore: remove prereleasing

### DIFF
--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -20,25 +20,3 @@ jobs:
         run: yarn install
       - name: Test
         run: yarn test
-  preRelease:
-    needs: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org
-      - name: Install
-        run: yarn install --frozen-lockfile
-      - name: Version
-        env:
-          PRE_ID: pr-${{ github.event.number }}-${{ github.run_id }}
-        run: npm version prepatch --git-tag-version=false --preid="${PRE_ID}-$(date '+%s')"
-      - name: PrePublish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.LIFEOMIC_NPM_TOKEN}}
-          PR_TAG: pr-${{ github.event.number }}
-        run: |
-          yarn build
-          npm publish ./dist/ --tag "${PR_TAG}" 


### PR DESCRIPTION
## Motivation
In our new workflow for publishing NPM packages, pre-releasing on PRs is not supported.

We haven't yet identified a good solution -- for now, `yarn link` needs to be used.