### PR TITLE
perf: add javascript eslint rule for using path based lodash tree shaking

### DIFF
--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -49,6 +49,19 @@ module.exports = {
     'require-await': 'error',
     'no-sequences': 'error',
     'wrap-iife': ['error', 'any'],
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'lodash',
+            message:
+              "Please use `import [package] from 'lodash/[package]'` instead.",
+          }
+        ],
+        patterns: ['!lodash/*'],
+      },
+    ],
 
     // This rule is similar to `prefer-arrow-callback`, but also enforces
     // the general use of () => { ... } over `function` declarations


### PR DESCRIPTION
for saving us from importing all of lodash and enduring that large import cost. Example (replace any lodash function for `get`):
| Good | Bad |
| - | - |
| `import get from 'lodash/get'` | `import { get } from 'lodash'` |