### PR TITLE
fix: move eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@lifeomic/typescript-config": "^3.0.0",
     "conventional-changelog-conventionalcommits": "^6.1.0",
+    "eslint": "^8",
     "eslint-config-eslint": "^8.0.0",
     "eslint-plugin-eslint-plugin": "^5.1.1",
     "eslint-plugin-node": "^11.1.0",
@@ -28,7 +29,6 @@
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",
-    "eslint": "^8",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-jsdoc": "^46.4.4",
     "eslint-plugin-prefer-arrow": "^1.2.3"


### PR DESCRIPTION
## Motivation
`eslint` should definitely not be a production dependency here.