### PR TITLE
Proposal: add import sorting to the base config

### DIFF
--- a/lib/javascript.js
+++ b/lib/javascript.js
@@ -15,6 +15,7 @@ module.exports = {
   plugins: [
     'prefer-arrow',
     'jsdoc',
+    'simple-import-sort',
   ],
   rules: {
     eqeqeq: 'error',
@@ -83,5 +84,26 @@ module.exports = {
     indent: ['error', 2, {
       SwitchCase: 1,
     }],
+
+    'simple-import-sort/exports': 'error',
+    'simple-import-sort/imports': [
+      'error',
+      {
+        groups: [
+          // React related packages come first.
+          ['^react', '^@?\\w'],
+          // Internal packages.
+          ['^(@|components)(/.*|$)'],
+          // Side effect imports.
+          ['^\\u0000'],
+          // Parent imports. Put `..` last.
+          ['^\\.\\.(?!/?$)', '^\\.\\./?$'],
+          // Other relative imports. Put same-folder imports and `.` last.
+          ['^\\./(?=.*/)(?!/?$)', '^\\.(?!/?$)', '^\\./?$'],
+          // Style imports.
+          ['^.+\\.?(css)$'],
+        ],
+      },
+    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@typescript-eslint/parser": "^6.2.0",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-jsdoc": "^46.4.4",
-    "eslint-plugin-prefer-arrow": "^1.2.3"
+    "eslint-plugin-prefer-arrow": "^1.2.3",
+    "eslint-plugin-simple-import-sort": "^10.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2354,6 +2354,11 @@ eslint-plugin-prefer-arrow@^1.2.3:
   resolved "https://registry.yarnpkg.com/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz#e7fbb3fa4cd84ff1015b9c51ad86550e55041041"
   integrity sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==
 
+eslint-plugin-simple-import-sort@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz#cc4ceaa81ba73252427062705b64321946f61351"
+  integrity sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==
+
 eslint-plugin-unicorn@^42.0.0:
   version "42.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-42.0.0.tgz#47d60c00c263ad743403b052db689e39acbacff1"


### PR DESCRIPTION
## Motivation
We've been using this plugin to automatically sort imports in an internal project for some time. When combined with ESLint's "fix on save" feature in VSCode, the experience is _great_. I never have to think about import order, and imports are sorted automatically whenever I save. Plus, the ordering of imports is consistent between files.

My experience has been so great that I'd like to propose adding it to our core config.